### PR TITLE
Flags start/arrival instead of 1/2 + Titles

### DIFF
--- a/src/z_zip_diff_demo2.prog.abap
+++ b/src/z_zip_diff_demo2.prog.abap
@@ -1,0 +1,23 @@
+*&---------------------------------------------------------------------*
+*& Report z_zip_diff_demo2
+*&---------------------------------------------------------------------*
+*&
+*&---------------------------------------------------------------------*
+REPORT z_zip_diff_demo2.
+
+DATA zip_diff TYPE REF TO zcl_zip_diff_viewer2.
+
+PARAMETERS dummy.
+
+AT SELECTION-SCREEN OUTPUT.
+  IF zip_diff IS NOT BOUND.
+    zip_diff = NEW #( cl_gui_container=>screen0 ).
+    DATA(zip_old) = NEW cl_abap_zip( ).
+    zip_old->add( name = 'changed.txt' content = cl_abap_codepage=>convert_to( 'hello world' ) ).
+    zip_old->add( name = 'deleted.txt' content = cl_abap_codepage=>convert_to( 'I was deleted' ) ).
+    DATA(zip_new) = NEW cl_abap_zip( ).
+    zip_new->add( name = 'added.txt' content = cl_abap_codepage=>convert_to( 'I was added' ) ).
+    zip_old->add( name = 'changed.txt' content = cl_abap_codepage=>convert_to( 'hey world' ) ).
+    zip_diff->diff_and_view( title_old = 'Web Repository .zip file' title_new = 'Demo program .zip file'
+                              zip_old = zip_old zip_new = zip_new ).
+  ENDIF.

--- a/src/z_zip_diff_demo2.prog.abap
+++ b/src/z_zip_diff_demo2.prog.abap
@@ -23,7 +23,7 @@ AT SELECTION-SCREEN OUTPUT.
     zip_old->add( name = 'deleted.txt' content = cl_abap_codepage=>convert_to( 'I was deleted' ) ).
     DATA(zip_new) = NEW cl_abap_zip( ).
     zip_new->add( name = 'added.txt' content = cl_abap_codepage=>convert_to( 'I was added' ) ).
-    zip_old->add( name = 'changed.txt' content = cl_abap_codepage=>convert_to( 'hey world' ) ).
+    zip_new->add( name = 'changed.txt' content = cl_abap_codepage=>convert_to( 'hey world' ) ).
     zip_diff->diff_and_view( title_old = 'Web Repository .zip file' title_new = 'Demo program .zip file'
                               zip_old = zip_old zip_new = zip_new ).
   ENDIF.

--- a/src/z_zip_diff_demo2.prog.abap
+++ b/src/z_zip_diff_demo2.prog.abap
@@ -10,6 +10,12 @@ DATA zip_diff TYPE REF TO zcl_zip_diff_viewer2.
 PARAMETERS dummy.
 
 AT SELECTION-SCREEN OUTPUT.
+  DATA(excluded_functions) = VALUE ui_functions( ( 'ONLI' ) ( 'PRIN' ) ( 'SPOS' ) ).
+  CALL FUNCTION 'RS_SET_SELSCREEN_STATUS'
+    EXPORTING
+      p_status  = sy-pfkey
+    TABLES
+      p_exclude = excluded_functions.
   IF zip_diff IS NOT BOUND.
     zip_diff = NEW #( cl_gui_container=>screen0 ).
     DATA(zip_old) = NEW cl_abap_zip( ).

--- a/src/z_zip_diff_demo2.prog.xml
+++ b/src/z_zip_diff_demo2.prog.xml
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_PROG" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <PROGDIR>
+    <NAME>Z_ZIP_DIFF_DEMO2</NAME>
+    <DBAPL>S</DBAPL>
+    <DBNA>D$</DBNA>
+    <SUBC>1</SUBC>
+    <FIXPT>X</FIXPT>
+    <LDBNAME>D$S</LDBNAME>
+    <UCCHECK>X</UCCHECK>
+   </PROGDIR>
+   <TPOOL>
+    <item>
+     <ID>R</ID>
+     <ENTRY>Zip Diff Smallest Demo Program</ENTRY>
+     <LENGTH>30</LENGTH>
+    </item>
+   </TPOOL>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
Possibility to give names to ZIP files. New minimal demo `z_zip_diff_demo2`:
![image](https://user-images.githubusercontent.com/34005250/150645227-cbd1776e-834d-40dc-a163-356c849740eb.png)
- The initial file is the one in the "Web Repository", the arrival file is the one generated by demo program:
- (red) In the Web Repository, the ZIP had file "deleted.txt" but it's not in the ZIP generated by the demo program.
- (green) The demo program has generated a ZIP with file "added.txt" which is not in the ZIP of the "Web Repository".
- (yellow) "changed.txt" is changed
